### PR TITLE
feat(container): add gitlab and gitlab-redis to dev ns

### DIFF
--- a/kubernetes/main/apps/cert-manager/certificates/import/clusterexternalsecret.yaml
+++ b/kubernetes/main/apps/cert-manager/certificates/import/clusterexternalsecret.yaml
@@ -11,7 +11,7 @@ spec:
       - key: kubernetes.io/metadata.name
         operator: In
         values:
-          # - cert-manager
+          # - dev
           - network
   refreshTime: 1h
   externalSecretSpec:

--- a/kubernetes/main/apps/database/crunchy-pgo/cluster/cluster.yaml
+++ b/kubernetes/main/apps/database/crunchy-pgo/cluster/cluster.yaml
@@ -92,6 +92,11 @@ spec:
       databases: ["sonarr_main"]
       password:
         type: AlphaNumeric
+    - name: "gitlab"
+      databases: ["gitlab-ci", "gitlab"]
+      password:
+        type: AlphaNumeric
+
   backups:
     pgbackrest:
       configuration: &backupConfig

--- a/kubernetes/main/apps/dev/gitlab-redis/app/cluster.yaml
+++ b/kubernetes/main/apps/dev/gitlab-redis/app/cluster.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/dragonflydb.io/dragonfly_v1alpha1.json
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: gitlab-dragonfly
+spec:
+  image: ghcr.io/dragonflydb/dragonfly:v1.24.0
+  replicas: 3
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+  args:
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+    - --cluster_mode=emulated
+    - --default_lua_flags=allow-undeclared-keys
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 512Mi

--- a/kubernetes/main/apps/dev/gitlab-redis/app/gatus.yaml
+++ b/kubernetes/main/apps/dev/gitlab-redis/app/gatus.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gitlab-dragonfly-gatus-ep
+  labels:
+    gatus.io/enabled: "true"
+data:
+  config.yaml: |
+    endpoints:
+      - name: Redis - GitLab
+        group: infrastructure
+        url: tcp://gitlab-dragonfly.dev.svc.cluster.local:6379
+        interval: 1m
+        ui:
+          hide-url: true
+          hide-hostname: true
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: telegram
+            send-on-resolved: true

--- a/kubernetes/main/apps/dev/gitlab-redis/app/kustomization.yaml
+++ b/kubernetes/main/apps/dev/gitlab-redis/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./podmonitor.yaml
+  - ./gatus.yaml

--- a/kubernetes/main/apps/dev/gitlab-redis/app/podmonitor.yaml
+++ b/kubernetes/main/apps/dev/gitlab-redis/app/podmonitor.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: &appname gitlab-dragonfly
+spec:
+  selector:
+    matchLabels:
+      app: *appname
+  podTargetLabels: ["app"]
+  podMetricsEndpoints:
+    - port: admin

--- a/kubernetes/main/apps/dev/gitlab-redis/ks.yaml
+++ b/kubernetes/main/apps/dev/gitlab-redis/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname gitlab-redis
+  namespace: flux-system
+spec:
+  path: ./kubernetes/main/apps/dev/gitlab-redis/app
+  targetNamespace: dev
+  sourceRef:
+    kind: GitRepository
+    name: prod-kubernetes
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  prune: true
+  wait: false
+  interval: 10m
+  dependsOn:
+    - name: dragonfly

--- a/kubernetes/main/apps/dev/gitlab/app/externalsecret.yaml
+++ b/kubernetes/main/apps/dev/gitlab/app/externalsecret.yaml
@@ -1,0 +1,188 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitlab
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshInterval: 15m
+  target:
+    name: gitlab-secret
+    template:
+      engineVersion: v2
+      data:
+        GITLAB_INITIAL_ROOT_PASSWORD: "{{ .gitlab_root_password }}"
+        GITLAB_KAS_SHARED_SECRET: "{{ .gitlab_kas_shared_secret }}"
+        GITLAB_S3_ACCESS_KEY: "{{ .gitlab_s3_access_key }}"
+        GITLAB_S3_SECRET_KEY: "{{ .gitlab_s3_secret_key }}"
+        GITLAB_S3_DEFAULT_REGION: "{{ .minio_region }}"
+        GITLAB_S3_ENDPOINT: "{{ .minio_endpoint }}"
+        SMTP_SERVER: "{{ .gitlab_email_server }}"
+        SMTP_USERNAME: "{{ .gitlab_email_from }}"
+        SMTP_PORT: "25"
+        EMAIL_DISPLAY_NAME: "{{ .gitlab_email_display_name }}"
+        EMAIL_FROM: "{{ .gitlab_email_from }}"
+        EMAIL_REPLY_TO: "{{ .gitlab_email_reply_to }}"
+  dataFrom:
+    - extract:
+        key: gitlab
+    - extract:
+        key: minio
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitlab-db
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshInterval: 15m
+  target:
+    name: gitlab-db-secret
+    template:
+      engineVersion: v2
+      data: # TODO: this
+        s3.conf: |
+          [global]
+          repo1-s3-key={{ .crunchy_s3_access_key }}
+          repo1-s3-key-secret={{ .crunchy_s3_secret_key }}
+          repo2-s3-key={{ .r2_access_key }}
+          repo2-s3-key-secret={{ .r2_secret_key }}
+        encryption.conf: |
+          [global]
+          repo1-cipher-pass={{ .crunchy_minio_backup_pass }}
+          repo2-cipher-pass={{ .crunchy_r2_backup_pass }}
+  dataFrom:
+    - extract:
+        key: gitlab
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitlab-registry
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshInterval: 15m
+  target:
+    name: gitlab-registry-secret
+    template:
+      engineVersion: v2
+      data:
+        config: |
+          s3:
+            v4auth: true
+            pathstyle: true
+            regionendpoint: "{{ .minio_endpoint }}"
+            region: "{{ .minio_region }}"
+            bucket: "{{ .gitlab_registry_bucket_name }}"
+            accesskey: "{{ .gitlab_registry_s3_access_key }}"
+            secretkey: "{{ .gitlab_registry_s3_secret_key }}"
+  dataFrom:
+    - extract:
+        key: gitlab
+    - extract:
+        key: minio
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitlab-connection
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshInterval: 15m
+  target:
+    name: gitlab-connection-secret
+    template:
+      engineVersion: v2
+      data:
+        connection: |
+          provider: AWS
+          path_style: true
+          aws_signature_version: 4
+          region: "{{ .minio_region }}"
+          aws_access_key_id: "{{ .gitlab_s3_access_key }}"
+          aws_secret_access_key: "{{ .gitlab_s3_secret_key}}"
+          host: "{{ .minio_server }}"
+          endpoint: "{{ .minio_endpoint }}"
+  dataFrom:
+    - extract:
+        key: gitlab
+    - extract:
+        key: minio
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitlab-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  refreshInterval: 15m
+  target:
+    name: gitlab-oidc-secret
+    template:
+      engineVersion: v2
+      data:
+        provider: |
+          name: 'openid_connect',
+          label: 'SSO',
+          args: {
+            name: 'openid_connect',
+            scope: ['openid','profile','email'],
+            response_type: 'code',
+            issuer: 'https://sso.${CLUSTER_SECRET_PRD_DOMAIN}/application/o/gitlab/',
+            discovery: true,
+            client_auth_method: 'query',
+            uid_field: 'preferred_username',
+            send_scope_to_token_endpoint: 'true',
+            pkce: true,
+            client_options: {
+              identifier: "{{ .gitlab_oidc_client_id }}",
+              secret: "{{ .gitlab_oidc_client_secret }}",
+              redirect_uri: "https://gitlab.${CLUSTER_SECRET_PRD_DOMAIN}/users/auth/openid_connect/callback"
+  dataFrom:
+    - extract:
+        key: gitlab
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitlab-s3cmd
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gitlab-s3cmd-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        local: |
+          [default]
+          host_base = "{{ .minio_server }}"
+          host_bucket = "{{ .minio_server }}"
+          bucket_location = "{{ .minio_region }}"
+          use_https = True
+          accesskey = "{{ .gitlab_s3_access_key }}"
+          accesstoken = "{{ .gitlab_s3_secret_key }}"
+          signature_v2 = False
+  dataFrom:
+    - extract:
+        key: gitlab
+    - extract:
+        key: minio

--- a/kubernetes/main/apps/dev/gitlab/app/helmrelease.yaml
+++ b/kubernetes/main/apps/dev/gitlab/app/helmrelease.yaml
@@ -1,0 +1,333 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gitlab
+spec:
+  interval: 15m
+  timeout: 20m
+  chart:
+    spec:
+      chart: gitlab
+      version: 8.5.0
+      sourceRef:
+        kind: HelmRepository
+        name: gitlab
+        namespace: flux-system
+      interval: 15m
+
+  driftDetection:
+    mode: enabled
+  maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+
+  # https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/values.yaml
+  values:
+    global:
+      edition: ee
+      time_zone: ${TIMEZONE}
+      extraEnv:
+        GITLAB_LOG_LEVEL: 'info'
+        GITLAB_ALLOW_SEPARATE_CI_DATABASE: 1
+      hosts:
+        domain: ${CLUSTER_SECRET_PRD_DOMAIN}
+        pages:
+          name: ${CLUSTER_SECRET_DEV_DOMAIN}
+      ingress:
+        configureCertmanager: false
+        class: &class external
+        annotations:
+          external-dns.alpha.kubernetes.io/target: external.${CLUSTER_SECRET_PRD_DOMAIN}
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+          nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+          # nginx.ingress.kubernetes.io/server-snippets: |
+          #   location / {
+          #     proxy_set_header Upgrade $http_upgrade;
+          #     proxy_http_version 1.1;
+          #     proxy_set_header X-Forwarded-Host $http_host;
+          #     proxy_set_header X-Forwarded-Proto $scheme;
+          #     proxy_set_header X-Forwarded-For $remote_addr;
+          #     proxy_set_header Host $host;
+          #     proxy_set_header Connection "upgrade";
+          #     proxy_cache_bypass $http_upgrade;
+          #   }
+      monitoring:
+        enabled: true
+      initialRootPassword:
+        secret: &secret gitlab-secret
+        key: GITLAB_INITIAL_ROOT_PASSWORD
+      psql:
+        main:
+          database: gitlab
+          password:
+            useSecret: true
+            secret: *db-secret
+            key: PASSWORD
+        ci:
+          database: gitlab-ci
+          enabled: true
+          password:
+            useSecret: true
+            secret: *db-secret
+            key: PASSWORD
+      redis:
+        host: gitlab-dragonfly.dev.svc.cluster.local
+        auth:
+          enabled: false
+      praefect:
+        enabled: false
+      minio:
+        enabled: false
+      ## START appConfig
+      appConfig:
+        enableUsagePing: false
+        enableSeatLink: false
+        enableImpersonation: true
+        usernameChangingEnabled: false
+        contentSecurityPolicy:
+          enabled: true
+          report_only: false
+        object_store:
+          enabled: true
+          proxy_download: true
+          connection: &conn
+            secret: gitlab-connection-secret
+            key: connection
+        lfs:
+          enabled: true
+          bucket: gitlab-lfs
+          connection: *conn
+        artifacts:
+          enabled: true
+          bucket: gitlab-artifacts
+          connection: *conn
+        uploads:
+          enabled: true
+          bucket: gitlab-uploads
+          connection: *conn
+        packages:
+          enabled: true
+          bucket: gitlab-packages
+          connection: *conn
+        externalDiffs:
+          enabled: true
+          when: outdated
+          bucket: gitlab-external-diffs
+          connection: *conn
+        terraformState:
+          enabled: true
+          bucket: gitlab-terraform-state
+          connection: *conn
+        ciSecureFiles:
+          enabled: true
+          bucket: gitlab-ci-secure-files
+          connection: *conn
+        dependencyProxy:
+          enabled: true
+          bucket: gitlab-dependency-proxy
+          connection: *conn
+        backups:
+          bucket: gitlab-backups
+          tmpBucket: gitlab-tmp
+        ## https://docs.gitlab.com/charts/charts/globals#omniauth
+        ## https://docs.goauthentik.io/integrations/services/gitlab/#openid-connect-auth
+        omniauth:
+          enabled: true
+          allowSingleSignOn: ['openid_connect']
+          syncEmailFromProvider: 'openid_connect'
+          syncProfileFromProvider: ['openid_connect']
+          syncProfileAttributes: ['email']
+          autoSignInWithProvider: 'openid_connect'
+          blockAutoCreatedUsers: false
+          autoLinkSamlUser: true
+          autoLinkUser: ['openid_connect']
+          providers:
+            - secret: gitlab-oidc-secret
+              key: provider
+        ## https://docs.gitlab.com/charts/charts/globals#kas-settings
+        gitlab_kas:
+          enabled: true
+          secret: *secret
+          key: GITLAB_KAS_SHARED_SECRET
+
+      ## End of global.appConfig
+      ## https://docs.gitlab.com/charts/charts/globals#configure-registry-settings
+      registry:
+        bucket: gitlab-registry
+      pages:
+        enabled: true
+        host: ${CLUSTER_SECRET_DEV_DOMAIN}
+        objectStore:
+          enabled: true
+          bucket: gitlab-pages
+          proxy_download: true
+          connection:
+            secret: gitlab-connection-secret
+            key: connection
+      ## https://docs.gitlab.com/charts/charts/globals#outgoing-email
+      ## Email persona used in email sent by GitLab
+      email:
+        smime:
+          enabled: false
+
+    certmanager:
+      installCRDs: false
+      install: false
+    nginx-ingress:
+      enabled: false
+    haproxy:
+      install: false
+    prometheus:
+      install: false
+    postgresql:
+      install: false
+    traefik:
+      install: false
+    redis:
+      install: false
+
+    ## https://docs.gitlab.com/charts/charts/gitlab/kas/
+    kas:
+      enabled: true
+    ## https://docs.gitlab.com/charts/charts/registry/
+    registry:
+      enabled: true
+      storage:
+        secret: gitlab-registry-secret
+        key: config
+    gitlab-runner:
+      install: false
+    ## Settings for individual sub-charts under GitLab
+    ## Note: Many of these settings are configurable via globals
+    gitlab:
+      ## https://docs.gitlab.com/charts/charts/gitlab/toolbox
+      toolbox:
+        backups:
+          cron:
+            enabled: true
+            concurrencyPolicy: Replace
+            suspend: false
+            scheduled: "0 5 * * *"
+            successfulJobsHistoryLimit: 3
+            failedJobsHistoryLimit: 1
+            backoffLimit: 6
+            restartPolicy: "OnFailure"
+            resources:
+              requests:
+                cpu: 50m
+                memory: 350M
+          objectStorage:
+            config:
+              secret: gitlab-s3cmd-secret
+              key: local
+      gitaly:
+        resources:
+          requests:
+            cpu: 80m
+            memory: 660M
+          limits:
+            memory: 660M
+      webservice:
+        maxReplicas: 2
+        maxUnavailable: 1
+        minReplicas: 1
+        workerProcesses: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 2Gi
+      sidekiq:
+        maxReplicas: 2
+        maxUnavailable: 1
+        minReplicas: 1
+      gitlab-shell:
+        maxReplicas: 2
+        maxUnavailable: 1
+        minReplicas: 1
+      gitlab-registry:
+        maxReplicas: 2
+        maxUnavailable: 1
+        minReplicas: 1
+      gitlab-kas:
+        maxReplicas: 2
+        maxUnavailable: 1
+        minReplicas: 1
+      gitlab-pages:
+        ingress:
+          enabled: true
+          class: external
+          configureCertmanager: false
+          annotations:
+            external-dns.alpha.kubernetes.io/target: external.${CLUSTER_SECRET_DEV_DOMAIN}
+        maxReplicas: 2
+        maxUnavailable: 1
+        minReplicas: 1
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+
+  valuesFrom:
+    # MAIN DB
+    - kind: Secret
+      name: &db-secret gitlab-db-secret
+      valuesKey: HOST
+      targetPath: global.psql.main.host
+    - kind: Secret
+      name: *db-secret
+      valuesKey: DATABASE_NAME
+      targetPath: global.psql.main.database
+    - kind: Secret
+      name: *db-secret
+      valuesKey: LOGIN
+      targetPath: global.psql.main.username
+    # CI DB
+    - kind: Secret
+      name: *db-secret
+      valuesKey: HOST
+      targetPath: global.psql.ci.host
+    - kind: Secret
+      name: *db-secret
+      valuesKey: DATABASE_NAME
+      targetPath: global.psql.ci.database
+    - kind: Secret
+      name: *db-secret
+      valuesKey: LOGIN
+      targetPath: global.psql.ci.username
+    # EMAIL & SMTP
+    - kind: Secret
+      name: *secret
+      valuesKey: EMAIL_DISPLAY_NAME
+      targetPath: global.email.display_name
+    - kind: Secret
+      name: *secret
+      valuesKey: EMAIL_FROM
+      targetPath: global.email.from
+    - kind: Secret
+      name: *secret
+      valuesKey: EMAIL_REPLY_TO
+      targetPath: global.email.reply_to
+    - kind: Secret
+      name: *secret
+      valuesKey: SMTP_SERVER
+      targetPath: global.smtp.address
+    - kind: Secret
+      name: *secret
+      valuesKey: SMTP_USERNAME
+      targetPath: global.smtp.user_name
+    - kind: Secret
+      name: *secret
+      valuesKey: SMTP_PORT
+      targetPath: global.smtp.port
+
+
+

--- a/kubernetes/main/apps/dev/gitlab/app/kustomization.yaml
+++ b/kubernetes/main/apps/dev/gitlab/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ../../../../templates/gatus/external

--- a/kubernetes/main/apps/dev/gitlab/ks.yaml
+++ b/kubernetes/main/apps/dev/gitlab/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gitlab
+  namespace: flux-system
+spec:
+  path: ./kubernetes/main/apps/dev/gitlab/app
+  targetNamespace: dev
+  sourceRef:
+    kind: GitRepository
+    name: prod-kubernetes
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: &appname gitlab
+  prune: true
+  wait: false
+  interval: 10m
+  dependsOn:
+    - name: crunchy-postgres-operator-cluster
+    - name: gitlab-redis
+    - name: nginx-external
+  postBuild:
+    substitute:
+      APP: *appname
+      GATUS_SUBDOMAIN: gitlab

--- a/kubernetes/main/apps/dev/kustomization.yaml
+++ b/kubernetes/main/apps/dev/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Pre Flux-Kustomizations
+  - ./namespace.yaml
+  # Flux-Kustomizations
+  # - ./gitlab/ks.yaml
+  # - ./gitlab-redis/ks.yaml

--- a/kubernetes/main/apps/dev/namespace.yaml
+++ b/kubernetes/main/apps/dev/namespace.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    volsync.backube/privileged-movers: "true"
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/provider_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: alert-manager
+  namespace: dev
+spec:
+  type: alertmanager
+  address: http://alertmanager-operated.observability.svc.cluster.local:9093/api/v2/alerts/
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/alert_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: alert-manager
+  namespace: dev
+spec:
+  providerRef:
+    name: alert-manager
+  eventSeverity: error
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  exclusionList:
+    - "error.*lookup github\\.com"
+    - "error.*lookup raw\\.githubusercontent\\.com"
+    - "dial.*tcp.*timeout"
+    - "waiting.*socket"
+  suspend: false

--- a/kubernetes/main/apps/network/nginx/external/helmrelease.yaml
+++ b/kubernetes/main/apps/network/nginx/external/helmrelease.yaml
@@ -29,6 +29,8 @@ spec:
       valuesKey: MAXMIND_LICENSE_KEY
   values:
     fullnameOverride: nginx-external
+    tcp:
+      "22": "dev/gitlab-gitlab-shell:22"
     controller:
       replicaCount: 2
       service:

--- a/kubernetes/main/flux/repositories/helm/gitlab-workspace.yaml
+++ b/kubernetes/main/flux/repositories/helm/gitlab-workspace.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: gitlab-workspace
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://gitlab.com/api/v4/projects/gitlab-org%2fremote-development%2fgitlab-workspaces-proxy/packages/helm/devel

--- a/kubernetes/main/flux/repositories/helm/gitlab.yaml
+++ b/kubernetes/main/flux/repositories/helm/gitlab.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: gitlab
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.gitlab.io

--- a/kubernetes/main/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/main/flux/repositories/helm/kustomization.yaml
@@ -21,6 +21,8 @@ resources:
   - ./emqx.yaml
   - ./external-dns.yaml
   - ./external-secrets.yaml
+  - ./gitlab-workspace.yaml
+  - ./gitlab.yaml
   - ./grafana.yaml
   - ./ingress-nginx.yaml
   - ./intel.yaml

--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -112,6 +112,22 @@ module "proxy-lidarr" {
 #   auth_groups        = [authentik_group.users.id]
 # }
 
+module "oauth2-gitlab" {
+  source             = "./oauth2_application"
+  name               = "GitLab"
+  icon_url           = "https://cdn.monosense.io/branding/gitlab.png"
+  launch_url         = "https://gitlab.${module.secret_authentik.fields["authentik_cluster_domain"]}"
+  description        = "Private SCM"
+  newtab             = true
+  group              = "Developers"
+  sub_mode           = "user_email"
+  auth_groups        = [authentik_group.developers.id]
+  authorization_flow = resource.authentik_flow.provider-authorization-implicit-consent.uuid
+  client_id          = module.secret_gitlab.fields["gitlab_oidc_client_id"]
+  client_secret      = module.secret_gitlab.fields["gitlab_oidc_client_secret"]
+  redirect_uris      = ["https://gitlab.${module.secret_authentik.fields["authentik_cluster_domain"]}/users/auth/openid_connect/callback"]
+}
+
 module "oauth2-grafana" {
   source             = "./oauth2_application"
   name               = "Grafana"

--- a/terraform/authentik/directory.tf
+++ b/terraform/authentik/directory.tf
@@ -17,6 +17,11 @@ resource "authentik_group" "external" {
   is_superuser = false
 }
 
+resource "authentik_group" "developers" {
+  name         = "developers"
+  is_superuser = false
+}
+
 resource "authentik_group" "media" {
   name         = "media"
   is_superuser = false
@@ -47,6 +52,7 @@ resource "authentik_user" "monosense" {
     authentik_group.superusers.id,
     authentik_group.media.id,
     authentik_group.infrastructure.id,
-    authentik_group.nextcloud.id
+    authentik_group.nextcloud.id,
+    authentik_group.developers.id
   ]
 }

--- a/terraform/authentik/main.tf
+++ b/terraform/authentik/main.tf
@@ -29,6 +29,12 @@ module "secret_grafana" {
   item   = "grafana"
 }
 
+module "secret_gitlab" {
+  source = "github.com/bjw-s/terraform-1password-item?ref=main"
+  vault  = "Automation"
+  item   = "gitlab"
+}
+
 module "secret_ocis" {
   source = "github.com/bjw-s/terraform-1password-item?ref=main"
   vault  = "Automation"

--- a/terraform/authentik/oauth2_application/variables.tf
+++ b/terraform/authentik/oauth2_application/variables.tf
@@ -58,7 +58,10 @@ variable "issuer_mode" {
   type    = string
   default = "per_provider"
 }
-
+## https://registry.terraform.io/providers/goauthentik/authentik/latest/docs/resources/provider_oauth2#sub_mode
+# Allowed values are :
+# hashed_user_id, user_id, user_uuid, user_username, user_email, user_upn
+# for user_upn defaults to hashed_user_id
 variable "sub_mode" {
   type    = string
   default = "hashed_user_id"

--- a/terraform/minio/gitlab-artifacts.tf
+++ b/terraform/minio/gitlab-artifacts.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-artifacts" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-artifacts"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_artifacts_s3_secret_key"
+}

--- a/terraform/minio/gitlab-backups.tf
+++ b/terraform/minio/gitlab-backups.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-backups" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-backups"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_backups_s3_secret_key"
+}

--- a/terraform/minio/gitlab-ci-secure.tf
+++ b/terraform/minio/gitlab-ci-secure.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-ci-secure-files" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-ci-secure-files"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_ci_s3_secret_key"
+}

--- a/terraform/minio/gitlab-dependency-proxy.tf
+++ b/terraform/minio/gitlab-dependency-proxy.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-dependency-proxy" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-dependency-proxy"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_dependency_proxy_s3_secret_key"
+}

--- a/terraform/minio/gitlab-external-diffs.tf
+++ b/terraform/minio/gitlab-external-diffs.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-external-diffs" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-external-diffs"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_external_diffs_s3_secret_key"
+}

--- a/terraform/minio/gitlab-lfs.tf
+++ b/terraform/minio/gitlab-lfs.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-lfs" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-lfs"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_lfs_s3_secret_key"
+}

--- a/terraform/minio/gitlab-packages.tf
+++ b/terraform/minio/gitlab-packages.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-packages" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-packages"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_packages_s3_secret_key"
+}

--- a/terraform/minio/gitlab-pages.tf
+++ b/terraform/minio/gitlab-pages.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-pages" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-pages"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_pages_s3_secret_key"
+}

--- a/terraform/minio/gitlab-registry.tf
+++ b/terraform/minio/gitlab-registry.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-registry" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-registry"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_registry_s3_secret_key"
+}

--- a/terraform/minio/gitlab-terraform.tf
+++ b/terraform/minio/gitlab-terraform.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-terraform-state" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-terraform-state"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_terraform_s3_secret_key"
+}

--- a/terraform/minio/gitlab-tmp.tf
+++ b/terraform/minio/gitlab-tmp.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-tmp" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-tmp"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_tmp_s3_secret_key"
+}

--- a/terraform/minio/gitlab-uploads.tf
+++ b/terraform/minio/gitlab-uploads.tf
@@ -1,0 +1,8 @@
+module "s3_gitlab-uploads" {
+  source           = "./modules/minio"
+  vault            = "Automation"
+  bucket_name      = "gitlab-uploads"
+  # The OP provider converts the fields with toLower!
+  user_name        = "gitlab"
+  user_secret_item = "gitlab_uploads_s3_secret_key"
+}

--- a/terraform/minio/modules/minio/main.tf
+++ b/terraform/minio/modules/minio/main.tf
@@ -49,7 +49,6 @@ resource "minio_iam_user" "user" {
   #   secret        = var.user_secret
 }
 
-
 resource "minio_iam_user_policy_attachment" "user_rw" {
   user_name   = minio_iam_user.user.id
   policy_name = minio_iam_policy.rw_policy.id


### PR DESCRIPTION
## Changes/New

### Crunchy PGO
- [x] Create PGSQL user `gitlab` with database `gitlab-ci` and `gitlab` .
### Terraform
1. [x] Add terraform-authentik provision `openid_connect`, add new authentik group `developer`
2. [x] Add terraform-minio provision for `gitlab-*` bucket(s) :
    - Create bucket `gitlab-pages`
    - Create bucket `gitlab-lfs`
    - Create bucket `gitlab-artifacts`
    - Create bucket `gitlab-uploads`
    - Create bucket `gitlab-packages`
    - Create bucket `gitlab-external-diffs`
    - Create bucket `gitlab-terraform-state`
    - Create bucket `gitlab-ci-secure-files`
    - Create bucket `gitlab-dependency-proxy`
    - Create bucket `gitlab-backups`
    - Create bucket `gitlab-tmp`
    - Create bucket `gitlab-registry`
### Ingress `external`
1. [x] Add tcp service for `gitlab-shell`
### Dragonfly/Redis
1. [x] Add dragonfly instance on dev namespace for `gitlab`
